### PR TITLE
Feat/#13

### DIFF
--- a/CurrencyConverterApp/CurrencyConverterApp/App/AppDelegate.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/App/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -30,7 +31,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
+    
+    // MARK: - Core Data stack
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+        */
+        let container = NSPersistentContainer(name: "CoreDataModel")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
 }
 

--- a/CurrencyConverterApp/CurrencyConverterApp/App/SceneDelegate.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/App/SceneDelegate.swift
@@ -47,8 +47,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+        CoreDataManager.shared.saveContext()
     }
-
-
 }
 

--- a/CurrencyConverterApp/CurrencyConverterApp/Extensions/Array+Extensions.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Extensions/Array+Extensions.swift
@@ -1,0 +1,32 @@
+//
+//  Array+Extensions.swift
+//  CurrencyConverterApp
+//
+//  Created by 박주성 on 4/18/25.
+//
+
+import Foundation
+
+extension Array where Element == ExchangeRateInfo {
+    static func fromDTO(_ dto: [String: Double]) -> [ExchangeRateInfo] {
+        dto
+            .map { ExchangeRateInfo(currencyCode: $0.key, rate: $0.value) }
+            .sorted { $0.currencyCode < $1.currencyCode }
+    }
+    
+    static func fromEntity(_ entity: [ExchangeRateEntity]) -> [ExchangeRateInfo] {
+        entity
+            .map { ExchangeRateInfo(
+                currencyCode: $0.currency ?? "알 수 없음",
+                rate: $0.rate,
+                isFavorite: $0.isFavorite
+            )}
+            .sorted {
+                if $0.isFavorite != $1.isFavorite {
+                    return $0.isFavorite
+                } else {
+                    return $0.currencyCode < $1.currencyCode
+                }
+            }
+    }
+}

--- a/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataManager.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataManager.swift
@@ -75,6 +75,21 @@ final class CoreDataManager {
         saveContext()
     }
     
+    func toggleFavorite(for currencyCode: String) {
+        let request: NSFetchRequest<ExchangeRateEntity> = ExchangeRateEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "currency == %@", currencyCode)
+        
+        do {
+            if let target = try context.fetch(request).first {
+                target.isFavorite.toggle()
+                saveContext()
+            }
+        } catch {
+            print("즐겨찾기 상태 토글 실패: \(error)")
+        }
+    }
+
+    
     func saveContext() {
         if context.hasChanges {
             do {

--- a/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataManager.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataManager.swift
@@ -31,6 +31,16 @@ final class CoreDataManager {
     }
     
     func saveExchangeRate(exchangeRates: [ExchangeRateInfo]) {
+        // 기존 데이터 삭제
+        let request: NSFetchRequest<NSFetchRequestResult> = ExchangeRateEntity.fetchRequest()
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        
+        do {
+            try context.execute(deleteRequest)
+        } catch {
+            print("기존 ExchangeRate 삭제 실패: \(error)")
+        }
+        
         exchangeRates.forEach {
             let entity = ExchangeRateEntity(context: context)
             entity.currency = $0.currencyCode

--- a/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataManager.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataManager.swift
@@ -1,0 +1,87 @@
+//
+//  CoreDataManager.swift
+//  CurrencyConverterApp
+//
+//  Created by 박주성 on 4/17/25.
+//
+
+import UIKit
+import CoreData
+
+final class CoreDataManager {
+    
+    static let shared = CoreDataManager()
+    
+    private lazy var context: NSManagedObjectContext = {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+            fatalError("AppDelegate를 찾을 수 없음")
+        }
+        return appDelegate.persistentContainer.viewContext
+    }()
+    
+    func fetchExchangeRate() -> [ExchangeRateEntity] {
+        let request: NSFetchRequest<ExchangeRateEntity> = ExchangeRateEntity.fetchRequest()
+        
+        do {
+            return try context.fetch(request)
+        } catch {
+            print("환율 정보 가져오기 실패: \(error.localizedDescription)")
+            return []
+        }
+    }
+    
+    func saveExchangeRate(exchangeRates: [ExchangeRateInfo]) {
+        exchangeRates.forEach {
+            let entity = ExchangeRateEntity(context: context)
+            entity.currency = $0.currencyCode
+            entity.country = $0.country
+            entity.rate = $0.rate
+            entity.isFavorite = false
+        }
+        
+        saveContext()
+    }
+    
+    func fetchNextUpdateTime() -> Int? {
+        let request: NSFetchRequest<ExchangeRateTimeStampEntity> = ExchangeRateTimeStampEntity.fetchRequest()
+        
+        do {
+            if let result = try context.fetch(request).first {
+                return Int(result.timeNextUpdateUnix)
+            } else {
+                return nil
+            }
+        } catch {
+            print("fetchTimeStamp 실패: \(error.localizedDescription)")
+            return nil
+        }
+    }
+    
+    func saveTimeStamp(last: Int, next: Int) {
+        // 기존 데이터 삭제
+        let request: NSFetchRequest<NSFetchRequestResult> = ExchangeRateTimeStampEntity.fetchRequest()
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        
+        do {
+            try context.execute(deleteRequest)
+        } catch {
+            print("기존 TimeStamp 삭제 실패: \(error)")
+        }
+        
+        // 새로운 데이터 저장
+        let entity = ExchangeRateTimeStampEntity(context: context)
+        entity.timeLastUpdateUnix = Int64(last)
+        entity.timeNextUpdateUnix = Int64(next)
+        saveContext()
+    }
+    
+    func saveContext() {
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                print("Context 저장 실패: \(error)")
+            }
+        }
+    }
+}

--- a/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E248" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier=""/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E248" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="ExchangeRateEntity" representedClassName="ExchangeRateEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="country" optional="YES" attributeType="String"/>
+        <attribute name="currency" optional="YES" attributeType="String"/>
+        <attribute name="isFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="rate" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="ExchangeRateTimeStampEntity" representedClassName="ExchangeRateTimeStampEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="timeLastUpdateUnix" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeNextUpdateUnix" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+</model>

--- a/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E248" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier=""/>

--- a/CurrencyConverterApp/CurrencyConverterApp/Models/ExchangeRateInfo.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Models/ExchangeRateInfo.swift
@@ -21,6 +21,16 @@ struct ExchangeRateInfo: Hashable {
     
     /// 환율 값 (예: 1350.123)
     let rate: Double
+    
+    var isFavorite: Bool = false
+}
+
+extension ExchangeRateInfo {
+    init(entity: ExchangeRateEntity) {
+        self.currencyCode = entity.currency ?? "알 수 없음"
+        self.rate = entity.rate
+        self.isFavorite = entity.isFavorite
+    }
 }
 
 // MARK: - 국가명 매핑

--- a/CurrencyConverterApp/CurrencyConverterApp/Models/ExchangeRateInfo.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Models/ExchangeRateInfo.swift
@@ -25,14 +25,6 @@ struct ExchangeRateInfo: Hashable {
     var isFavorite: Bool = false
 }
 
-extension ExchangeRateInfo {
-    init(entity: ExchangeRateEntity) {
-        self.currencyCode = entity.currency ?? "알 수 없음"
-        self.rate = entity.rate
-        self.isFavorite = entity.isFavorite
-    }
-}
-
 // MARK: - 국가명 매핑
 
 extension ExchangeRateInfo {

--- a/CurrencyConverterApp/CurrencyConverterApp/Network/ExchangeRateResponse.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Network/ExchangeRateResponse.swift
@@ -1,0 +1,15 @@
+//
+//  ExchangeRateResponse.swift
+//  CurrencyConverterApp
+//
+//  Created by 박주성 on 4/17/25.
+//
+
+
+// ExchangeRateResponse.swift
+
+struct ExchangeRateResponse {
+    let exchangeRateList: [ExchangeRateInfo]
+    let timeLastUpdateUnix: Int
+    let timeNextUpdateUnix: Int
+}

--- a/CurrencyConverterApp/CurrencyConverterApp/Network/ExchangeRatesDTO.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Network/ExchangeRatesDTO.swift
@@ -21,12 +21,4 @@ struct ExchangeRatesDTO: Decodable {
         case timeNextUpdateUnix = "time_next_update_unix"
         case rates
     }
-    
-    /// `ExchangeRateInfo` 배열로 변환된 가공 데이터
-    /// 알파벳순 정렬된 리스트 반환
-    var exchangeRateList: [ExchangeRateInfo] {
-        rates
-            .map { ExchangeRateInfo(currencyCode: $0.key, rate: $0.value) }
-            .sorted { $0.currencyCode < $1.currencyCode }
-    }
 }

--- a/CurrencyConverterApp/CurrencyConverterApp/Network/ExchangeRatesDTO.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Network/ExchangeRatesDTO.swift
@@ -11,8 +11,16 @@ import Foundation
 /// 전체 JSON 중 "rates" 키의 값만 사용
 struct ExchangeRatesDTO: Decodable {
     
+    let timeLastUpdateUnix: Int
+    let timeNextUpdateUnix: Int
     /// 통화 코드와 환율을 매핑한 딕셔너리 (예: ["KRW": 1350.123])
     let rates: [String: Double]
+    
+    enum CodingKeys: String, CodingKey {
+        case timeLastUpdateUnix = "time_last_update_unix"
+        case timeNextUpdateUnix = "time_next_update_unix"
+        case rates
+    }
     
     /// `ExchangeRateInfo` 배열로 변환된 가공 데이터
     /// 알파벳순 정렬된 리스트 반환

--- a/CurrencyConverterApp/CurrencyConverterApp/Network/NetworkManager.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Network/NetworkManager.swift
@@ -30,7 +30,7 @@ final class NetworkManager {
     /// 서버에서 최신 환율 데이터를 가져오는 비동기 메서드
     /// - Returns: `ExchangeRateInfo` 배열
     /// - Throws: `NetworkError`에 정의된 에러
-    func fetchExchangeRateData() async throws -> [ExchangeRateInfo] {
+    func fetchExchangeRateData() async throws -> ExchangeRateResponse {
         // URL 생성
         guard let url = URL(string: "https://open.er-api.com/v6/latest/USD") else {
             throw NetworkError.invalidURL
@@ -46,11 +46,14 @@ final class NetworkManager {
         }
         
         // JSON 디코딩
-        guard let exchangeRates = try? JSONDecoder().decode(ExchangeRatesDTO.self, from: data) else {
+        guard let dto = try? JSONDecoder().decode(ExchangeRatesDTO.self, from: data) else {
             throw NetworkError.decodingError
         }
         
-        // 변환된 리스트 반환
-        return exchangeRates.exchangeRateList
+        return ExchangeRateResponse(
+            exchangeRateList: dto.exchangeRateList,
+            timeLastUpdateUnix: dto.timeLastUpdateUnix,
+            timeNextUpdateUnix: dto.timeNextUpdateUnix
+        )
     }
 }

--- a/CurrencyConverterApp/CurrencyConverterApp/Network/NetworkManager.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Network/NetworkManager.swift
@@ -51,7 +51,7 @@ final class NetworkManager {
         }
         
         return ExchangeRateResponse(
-            exchangeRateList: dto.exchangeRateList,
+            exchangeRateList: .fromDTO(dto.rates),
             timeLastUpdateUnix: dto.timeLastUpdateUnix,
             timeNextUpdateUnix: dto.timeNextUpdateUnix
         )

--- a/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ExchangeRateViewModel.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ExchangeRateViewModel.swift
@@ -17,6 +17,7 @@ enum ExchangeRateState {
 enum ExchangeRateAction {
     case fetch              // 환율 데이터 전체 로드
     case applyFilter(String)    // 검색어를 통한 필터링
+    case favorite(String)
 }
 
 @MainActor
@@ -61,6 +62,8 @@ final class ExchangeRateViewModel: ViewModelProtocol {
                 self?.fetchExchangeRates()
             case .applyFilter(let keyword):
                 self?.filterExchangeRates(with: keyword)
+            case .favorite(let currencyCode):
+                self?.toggleFavorite(for: currencyCode)
             }
         }
     }
@@ -125,5 +128,10 @@ final class ExchangeRateViewModel: ViewModelProtocol {
         }
         // 필터링 결과 업데이트
         state = .exchangeRates(filtered)
+    }
+    
+    private func toggleFavorite(for currencyCode: String) {
+        CoreDataManager.shared.toggleFavorite(for: currencyCode)
+        fetchFromCoreData()
     }
 }

--- a/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ExchangeRateViewModel.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ExchangeRateViewModel.swift
@@ -71,10 +71,10 @@ final class ExchangeRateViewModel: ViewModelProtocol {
     nonisolated private func loadExchangeRates() {
         Task {
             do {
-                let rates = try await NetworkManager.shared.fetchExchangeRateData()
+                let response = try await NetworkManager.shared.fetchExchangeRateData()
                 await MainActor.run {
-                    allExchangeRates = rates
-                    state = .exchangeRates(rates)
+                    allExchangeRates = response.exchangeRateList
+                    state = .exchangeRates(response.exchangeRateList)
                 }
             } catch {
                 await MainActor.run {

--- a/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ExchangeRateViewModel.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ExchangeRateViewModel.swift
@@ -93,7 +93,7 @@ final class ExchangeRateViewModel: ViewModelProtocol {
                     last: response.timeLastUpdateUnix,
                     next: response.timeNextUpdateUnix
                 )
-                print(response.timeNextUpdateUnix)
+                
                 await MainActor.run {
                     allExchangeRates = response.exchangeRateList
                     state = .exchangeRates(response.exchangeRateList)

--- a/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ExchangeRateViewModel.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ExchangeRateViewModel.swift
@@ -108,7 +108,7 @@ final class ExchangeRateViewModel: ViewModelProtocol {
     
     private func fetchFromCoreData() {
         let entity = CoreDataManager.shared.fetchExchangeRate()
-        let rates = entity.map { ExchangeRateInfo(entity: $0) }
+        let rates: [ExchangeRateInfo] = .fromEntity(entity)
         allExchangeRates = rates
         state = .exchangeRates(rates)
     }

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateCell.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateCell.swift
@@ -25,14 +25,14 @@ final class ExchangeRateCell: UITableViewCell {
     
     /// 통화 코드와 국가명을 수직으로 정렬하는 스택 뷰
     private lazy var labelStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [currencyLable, countryLabel])
+        let stackView = UIStackView(arrangedSubviews: [currencyLabel, countryLabel])
         stackView.axis = .vertical
         stackView.spacing = 4
         return stackView
     }()
     
     /// 통화 코드 라벨 (예: USD, KRW)
-    private let currencyLable: UILabel = {
+    private let currencyLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .medium)
         label.textColor = .black
@@ -59,6 +59,9 @@ final class ExchangeRateCell: UITableViewCell {
     private lazy var favoriteButton: UIButton = {
         let button = UIButton()
         button.tintColor = .systemYellow
+        button.imageView?.contentMode = .scaleAspectFit
+        button.contentHorizontalAlignment = .fill
+        button.contentVerticalAlignment = .fill
         button.addTarget(self, action: #selector(favoriteButtonDidTap), for: .touchUpInside)
         return button
     }()
@@ -106,7 +109,7 @@ final class ExchangeRateCell: UITableViewCell {
             $0.leading.equalTo(exchangeRateLabel.snp.trailing).offset(16)
             $0.trailing.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
-            $0.width.height.equalTo(labelStackView.snp.height)
+            $0.width.height.equalTo(labelStackView.snp.height).multipliedBy(0.8)
         }
     }
     
@@ -114,7 +117,7 @@ final class ExchangeRateCell: UITableViewCell {
     
     @objc
     private func favoriteButtonDidTap() {
-        guard let currencyCode = currencyLable.text else { return }
+        guard let currencyCode = currencyLabel.text else { return }
         delegate?.favoriteButtonDidTap(for: currencyCode)
     }
     
@@ -126,9 +129,11 @@ final class ExchangeRateCell: UITableViewCell {
     ///   - country: 국가명 (예: 미국)
     ///   - exchangeRate: 환율 값 (예: 1324.1234)
     func configure(currency: String, country: String, exchangeRate: Double, isFavorite: Bool) {
-        currencyLable.text = currency
+        currencyLabel.text = currency
         countryLabel.text = country
         exchangeRateLabel.text = String(format: "%.4f", exchangeRate)
-        favoriteButton.setImage(isFavorite ? UIImage(systemName: "star.fill") : UIImage(systemName: "star"), for: .normal)
+        
+        let imageName = isFavorite == true ? "star.fill" : "star"
+        favoriteButton.setImage(UIImage(systemName: imageName), for: .normal)
     }
 }

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateCell.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateCell.swift
@@ -8,9 +8,17 @@
 import UIKit
 import SnapKit
 
+protocol ExchangeRateCellDelegate: AnyObject {
+    func favoriteButtonDidTap(for currencyCode: String)
+}
+
 final class ExchangeRateCell: UITableViewCell {
     
     // MARK: - Properties
+    
+    weak var delegate: ExchangeRateCellDelegate?
+    
+    // MARK: - UI Components
     
     /// 셀 재사용 식별자
     static let reuseIdentifier = "ExchangeRateCell"
@@ -48,9 +56,10 @@ final class ExchangeRateCell: UITableViewCell {
         return label
     }()
     
-    private let favoriteButton: UIButton = {
+    private lazy var favoriteButton: UIButton = {
         let button = UIButton()
         button.tintColor = .systemYellow
+        button.addTarget(self, action: #selector(favoriteButtonDidTap), for: .touchUpInside)
         return button
     }()
     
@@ -99,6 +108,14 @@ final class ExchangeRateCell: UITableViewCell {
             $0.centerY.equalToSuperview()
             $0.width.height.equalTo(labelStackView.snp.height)
         }
+    }
+    
+    // MARK: - Button Event
+    
+    @objc
+    private func favoriteButtonDidTap() {
+        guard let currencyCode = currencyLable.text else { return }
+        delegate?.favoriteButtonDidTap(for: currencyCode)
     }
     
     // MARK: - Configuration

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateCell.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateCell.swift
@@ -48,6 +48,12 @@ final class ExchangeRateCell: UITableViewCell {
         return label
     }()
     
+    private let favoriteButton: UIButton = {
+        let button = UIButton()
+        button.tintColor = .systemYellow
+        return button
+    }()
+    
     // MARK: - Initializers
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -64,12 +70,17 @@ final class ExchangeRateCell: UITableViewCell {
     /// 셀의 UI 구성 및 초기화
     private func setupUI() {
         self.contentView.backgroundColor = .white
+        self.selectionStyle = .none
         setupConstraints()
     }
     
     /// SnapKit을 사용하여 UI 제약 조건 설정
     private func setupConstraints() {
-        [labelStackView, exchangeRateLabel].forEach { contentView.addSubview($0) }
+        [
+            labelStackView,
+            exchangeRateLabel,
+            favoriteButton
+        ].forEach { contentView.addSubview($0) }
         
         labelStackView.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(16)
@@ -78,9 +89,15 @@ final class ExchangeRateCell: UITableViewCell {
         
         exchangeRateLabel.snp.makeConstraints {
             $0.leading.greaterThanOrEqualTo(labelStackView.snp.trailing).offset(16)
-            $0.trailing.equalToSuperview().inset(16)
             $0.width.equalTo(120)
             $0.centerY.equalToSuperview()
+        }
+        
+        favoriteButton.snp.makeConstraints {
+            $0.leading.equalTo(exchangeRateLabel.snp.trailing).offset(16)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(labelStackView.snp.height)
         }
     }
     
@@ -91,9 +108,10 @@ final class ExchangeRateCell: UITableViewCell {
     ///   - currency: 통화 코드 (예: USD)
     ///   - country: 국가명 (예: 미국)
     ///   - exchangeRate: 환율 값 (예: 1324.1234)
-    func configure(currency: String, country: String, exchangeRate: Double) {
+    func configure(currency: String, country: String, exchangeRate: Double, isFavorite: Bool) {
         currencyLable.text = currency
         countryLabel.text = country
         exchangeRateLabel.text = String(format: "%.4f", exchangeRate)
+        favoriteButton.setImage(isFavorite ? UIImage(systemName: "star.fill") : UIImage(systemName: "star"), for: .normal)
     }
 }

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateViewController.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateViewController.swift
@@ -145,7 +145,7 @@ final class ExchangeRateViewController: UIViewController {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([.main])
         snapshot.appendItems(items, toSection: .main)
-        datasource.apply(snapshot, animatingDifferences: false)
+        datasource.apply(snapshot)
         
         // 검색 결과가 없을 경우 빈 메시지 라벨을 배경으로 설정
         tableView.backgroundView = items.isEmpty ? emptyMessageLabel : nil

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateViewController.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateViewController.swift
@@ -118,6 +118,7 @@ final class ExchangeRateViewController: UIViewController {
                 exchangeRate: item.rate,
                 isFavorite: item.isFavorite
             )
+            cell.delegate = self
             
             return cell
         }
@@ -182,5 +183,11 @@ extension ExchangeRateViewController: UITableViewDelegate {
         let nextVM = CalculatorViewModel(exchangeRate: exchangeRate)
         let nextVC = CalculatorViewController(viewModel: nextVM)
         navigationController?.pushViewController(nextVC, animated: true)
+    }
+}
+
+extension ExchangeRateViewController: ExchangeRateCellDelegate {
+    func favoriteButtonDidTap(for currencyCode: String) {
+        viewModel.action?(.favorite(currencyCode))
     }
 }

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateViewController.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateViewController.swift
@@ -115,7 +115,8 @@ final class ExchangeRateViewController: UIViewController {
             cell.configure(
                 currency: item.currencyCode,
                 country: item.country,
-                exchangeRate: item.rate
+                exchangeRate: item.rate,
+                isFavorite: item.isFavorite
             )
             
             return cell


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #13

## 📌 변경 사항 및 이유
- `CoreData`를 활용한 **즐겨찾기 저장 및 삭제 로직** 구현
- 셀 우측에 ⭐ / ☆ **버튼 UI 추가** 및 `isFavorite` 상태에 따라 이미지 변경 처리
- 즐겨찾기된 항목은 **상단에 고정**, 일반 항목은 **알파벳 오름차순**으로 정렬되도록 로직 개선
- API 응답의 `time_next_update_unix` 값을 기준으로:
  - 업데이트가 필요한 경우 → **네트워크 요청 수행**
  - 그렇지 않은 경우 → **CoreData에 저장된 캐시 데이터 사용**

## 📌 PR Point
- 즐겨찾기 상태가 UI에 **즉시 반영**되는지
- 정렬이 **즐겨찾기 우선 > 알파벳순**으로 정확하게 적용되는지
- `time_next_update_unix` 기준의 네트워킹 조건 분기 로직이 올바르게 작동하는지

## 📌 참고 사항
- 즐겨찾기 버튼 탭 시 동작 흐름은 다음과 같습니다:  
  **CoreData 값 변경**  
  → **CoreData에서 전체 데이터 다시 fetch**  
  → **DiffableDataSource 스냅샷 갱신**  
  → **UI 업데이트**

- 정렬 기준:  
  → `isFavorite == true` 항목을 **상단에 고정**,  
  → 나머지는 `currencyCode` 기준 **오름차순 정렬**

- API 응답의 `time_next_update_unix` 값을 활용하여,  
  → **최신 데이터가 필요한 경우에만 네트워크 요청**  
  → **그 외에는 CoreData에서 데이터 로드**

<img src= "https://github.com/user-attachments/assets/a400c307-1572-4cb5-9ed0-70101ecb8f69" width="250" />