### PR TITLE
Feat/#15

### DIFF
--- a/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ViewModelProtocol.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ViewModelProtocol.swift
@@ -6,7 +6,7 @@
 //
 import Foundation
 
-@MainActor
+
 protocol ViewModelProtocol {
     associatedtype Action
     associatedtype State

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/CalculatorViewController.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/CalculatorViewController.swift
@@ -27,7 +27,6 @@ final class CalculatorViewController: UIViewController {
     private let currencyLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 24, weight: .bold)
-        label.textColor = .black
         label.textAlignment = .center
         return label
     }()
@@ -35,7 +34,7 @@ final class CalculatorViewController: UIViewController {
     private let countryLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .regular)
-        label.textColor = .gray
+        label.textColor = .secondaryLabel
         label.textAlignment = .center
         return label
     }()
@@ -46,6 +45,7 @@ final class CalculatorViewController: UIViewController {
         textField.keyboardType = .decimalPad
         textField.placeholder = "달러(USD)를 입력하세요"
         textField.textAlignment = .center
+        textField.backgroundColor = .secondarySystemBackground
         return textField
     }()
     
@@ -65,7 +65,6 @@ final class CalculatorViewController: UIViewController {
         let label = UILabel()
         label.text = "계산 결과가 여기에 표시됩니다"
         label.font = .systemFont(ofSize: 20, weight: .medium)
-        label.textColor = .black
         label.textAlignment = .center
         label.numberOfLines = 0
         return label
@@ -95,7 +94,7 @@ final class CalculatorViewController: UIViewController {
     // MARK: - UI Setup
     
     private func setupUI() {
-        view.backgroundColor = .white
+        view.backgroundColor = .secondarySystemBackground
         title = "환율 계산기"
         navigationController?.navigationBar.prefersLargeTitles = true
         setupConstraints()

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateCell.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateCell.swift
@@ -37,7 +37,6 @@ final class ExchangeRateCell: UITableViewCell {
     private let currencyLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .medium)
-        label.textColor = .black
         return label
     }()
     
@@ -45,7 +44,7 @@ final class ExchangeRateCell: UITableViewCell {
     private let countryLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 14, weight: .regular)
-        label.textColor = .gray
+        label.textColor = .secondaryLabel
         return label
     }()
     
@@ -53,7 +52,6 @@ final class ExchangeRateCell: UITableViewCell {
     private let exchangeRateLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .regular)
-        label.textColor = .black
         label.textAlignment = .right
         return label
     }()
@@ -89,7 +87,8 @@ final class ExchangeRateCell: UITableViewCell {
     
     /// 셀의 UI 구성 및 초기화
     private func setupUI() {
-        self.contentView.backgroundColor = .white
+        self.backgroundColor = .clear
+        self.contentView.backgroundColor = .clear
         self.selectionStyle = .none
         setupConstraints()
     }

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateViewController.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateViewController.swift
@@ -38,7 +38,7 @@ final class ExchangeRateViewController: UIViewController {
         let label = UILabel()
         label.text = "검색 결과 없음"
         label.textAlignment = .center
-        label.textColor = .gray
+        label.textColor = .secondaryLabel
         label.font = .systemFont(ofSize: 16, weight: .regular)
         return label
     }()
@@ -46,7 +46,7 @@ final class ExchangeRateViewController: UIViewController {
     /// 환율 정보를 표시할 테이블 뷰
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
-        tableView.backgroundColor = .white
+        tableView.backgroundColor = .clear
         tableView.rowHeight = 60
         tableView.delegate = self
         tableView.keyboardDismissMode = .onDrag
@@ -78,7 +78,7 @@ final class ExchangeRateViewController: UIViewController {
     
     /// UI 요소들을 초기화하고 배치
     private func setupUI() {
-        view.backgroundColor = .white
+        view.backgroundColor = .secondarySystemBackground
         title = "환율 정보"
         navigationController?.navigationBar.prefersLargeTitles = true
         setupConstraints()


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #15 

## 📌 변경 사항 및 이유
- label, systemBackground, secondaryLabel 등의 시스템 색상 적용하여 다크 모드 대응

## 📌 PR Point
다크모드에서 UI 요소(텍스트, 배경, 구분선 등)의 가시성

<br>

|             | 환율화면       | 계산기화면     |
|-------------|----------------|----------------|
| 라이트 모드 | <img src="https://github.com/user-attachments/assets/fc9f64b0-7d17-4364-925c-7cec80ab2595" width="250" /> | <img src="https://github.com/user-attachments/assets/1492b1ea-3299-4590-960f-552db317cba6" width="250" /> |
| 다크 모드   | <img src="https://github.com/user-attachments/assets/e0c99446-e993-4acd-8aa7-52529611dfc8" width="250" /> | <img src="https://github.com/user-attachments/assets/d90cf3ed-0ec8-4a09-8255-df7096ebf510" width="250" /> |