### PR TITLE
Feat/#16

### DIFF
--- a/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/CurrencyConverterApp/CurrencyConverterApp/Models/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -10,4 +10,8 @@
         <attribute name="timeLastUpdateUnix" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="timeNextUpdateUnix" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
+    <entity name="LastViewedScreenEntity" representedClassName="LastViewedScreenEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="currencyCode" optional="YES" attributeType="String"/>
+        <attribute name="screenType" optional="YES" attributeType="String"/>
+    </entity>
 </model>

--- a/CurrencyConverterApp/CurrencyConverterApp/ViewModels/CalculatorViewModel.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/ViewModels/CalculatorViewModel.swift
@@ -25,7 +25,7 @@ final class CalculatorViewModel: ViewModelProtocol {
     
     // MARK: - Properties
     
-    private(set) var state: State {
+    var state: State {
         didSet {
             onStateChange?(state)
         }

--- a/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ExchangeRateViewModel.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/ViewModels/ExchangeRateViewModel.swift
@@ -35,7 +35,7 @@ final class ExchangeRateViewModel: ViewModelProtocol {
 
     // MARK: - Properties
 
-    private(set) var state: State {
+    var state: State {
         didSet {
             Task { @MainActor in
                 onStateChange?(state)
@@ -45,7 +45,7 @@ final class ExchangeRateViewModel: ViewModelProtocol {
     
     private var allExchangeRates: [ExchangeRateInfo] = []
     
-    private(set) var action: ((Action) -> Void)?
+    var action: ((Action) -> Void)?
     var onStateChange: ((State) -> Void)?
 
     // MARK: - Initializer

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/CalculatorViewController.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/CalculatorViewController.swift
@@ -14,6 +14,11 @@ final class CalculatorViewController: UIViewController {
     
     private let viewModel: CalculatorViewModel
     
+    /// 마지막에 본 화면을 저장할 때 사용할 currencyCode
+    var currencyCode: String {
+        return viewModel.exchangeRate.currencyCode
+    }
+    
     // MARK: - UI Components
     
     private lazy var labelStackView: UIStackView = {

--- a/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateCell.swift
+++ b/CurrencyConverterApp/CurrencyConverterApp/Views/ExchangeRateCell.swift
@@ -87,8 +87,8 @@ final class ExchangeRateCell: UITableViewCell {
     
     /// 셀의 UI 구성 및 초기화
     private func setupUI() {
-        self.backgroundColor = .clear
-        self.contentView.backgroundColor = .clear
+        self.backgroundColor = .secondarySystemBackground
+        self.contentView.backgroundColor = .secondarySystemBackground
         self.selectionStyle = .none
         setupConstraints()
     }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #16  

## 📌 변경 사항 및 이유
- 사용자가 마지막으로 본 화면 정보를 CoreData에 저장하도록 구현
- 앱이 백그라운드로 진입할 때, `sceneDidEnterBackground`에서 현재 화면 상태를 저장
  - CoreData 내부에서는 `performAndWait`를 사용하여 **동기적으로 저장되도록 구성**하여, 앱 종료 직전에도 데이터 유실을 방지
- 앱 재실행 시(`SceneDelegate.scene(_:willConnectTo:)`) 복원된 데이터를 기준으로:
  - **루트는 항상 `ExchangeRateViewController`**로 설정하고,
  - 마지막 화면이 계산기인 경우에는 해당 통화의 계산기 화면을 **0.4초 지연 후 `pushViewController` 방식으로 복원**
  - 환율 데이터는 CoreData에서 조회하여 매칭되는 `ExchangeRateInfo`로 복원

## 📌 PR Point
- 복원 흐름이 `ExchangeRateViewController` → `CalculatorViewController`로 자연스럽게 이어지는지
- 계산기 화면 복원 시 CoreData에서 환율 데이터를 조회하여 정확하게 처리되는지
- ViewController 간 상태 전달 및 식별 정보(`currencyCode`) 노출 방식의 적절성

## 📌 참고 사항
- 저장 시점: `sceneDidEnterBackground`에서 `Task { await ... }` 구조로 저장 트리거
- 저장 대상: `LastViewedScreenEntity` (화면 타입 + currencyCode)
- 복원 시점: 앱 실행 직후 `SceneDelegate.scene(_:willConnectTo:)`에서 `CoreDataManager.fetchLastViewedScreen()`을 호출해 화면 복원 흐름 시작
- push 방식: 계산기 화면은 `makeKeyAndVisible()` 이후 `0.4초 지연` 후 push
- 계산기 화면 복원 시 환율 정보는 `ExchangeRateInfo.fromEntity(_:)`에서 매칭하여 구성
- `CalculatorViewController`는 `currencyCode` 프로퍼티를 통해 외부에서 식별 가능

<br>

<img src="https://github.com/user-attachments/assets/67a83fc9-e2f6-4d0d-989f-569982e264a1" width="250" />